### PR TITLE
Add AdVenture Capitalist tab and simple Poker/Blackjack web games

### DIFF
--- a/adventure/icon.svg
+++ b/adventure/icon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#38bdf8"/>
+      <stop offset="100%" stop-color="#0ea5e9"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="48" fill="url(#sky)"/>
+  <circle cx="390" cy="122" r="48" fill="#fde047"/>
+  <rect x="74" y="250" width="364" height="174" rx="24" fill="#22c55e"/>
+  <text x="256" y="306" text-anchor="middle" font-size="42" font-family="Arial" fill="#064e3b" font-weight="700">ADVENTURE</text>
+  <text x="256" y="360" text-anchor="middle" font-size="60" font-family="Arial" fill="#78350f" font-weight="700">$</text>
+  <text x="256" y="412" text-anchor="middle" font-size="36" font-family="Arial" fill="#14532d" font-weight="700">CAPITALIST</text>
+</svg>

--- a/adventure/index.html
+++ b/adventure/index.html
@@ -1,43 +1,18 @@
 <!DOCTYPE html>
-<html>
-
+<html lang="en">
 <head>
-    <title>Error</title>
-    <style type="text/css">
-        html {
-            overflow: auto;
-        }
-        
-        html,
-        body,
-        div,
-        iframe {
-            margin: 0px;
-            padding: 0px;
-            height: 100%;
-            border: none;
-        }
-        
-        iframe {
-            display: block;
-            width: 100%;
-            border: none;
-            overflow-y: auto;
-            overflow-x: hidden;
-        }
-    </style>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AdVenture Capitalist</title>
+  <style>
+    html, body { margin:0; height:100%; background:#0b1220; }
+    .wrap { display:flex; align-items:center; justify-content:center; height:100%; }
+    iframe { width:min(1200px, 100vw); height:min(760px, 100vh); border:0; border-radius:12px; box-shadow:0 10px 35px rgba(0,0,0,.45); }
+  </style>
 </head>
-
 <body>
-    <iframe src="https://d1tm91r4ytbt54.cloudfront.net/83d8bca0-ad0b-4379-890c-9edf409cc73f/1681766175791/adcapitalist/index.html"
-            frameborder="0" 
-            marginheight="0" 
-            marginwidth="0" 
-            width="100%" 
-            height="100%" 
-            scrolling="auto">
-  </iframe>
-
+  <div class="wrap">
+    <iframe src="https://www.crazygames.com/embed/adventure-capitalist" title="AdVenture Capitalist" allow="gamepad *; fullscreen" allowfullscreen></iframe>
+  </div>
 </body>
-
 </html>

--- a/blackjack/icon.svg
+++ b/blackjack/icon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="bg2" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="100%" stop-color="#1e293b"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="48" fill="url(#bg2)"/>
+  <rect x="72" y="146" width="170" height="240" rx="16" fill="#fff"/>
+  <text x="98" y="205" font-size="52" font-family="Arial" fill="#111827" font-weight="700">10♣</text>
+  <rect x="190" y="110" width="170" height="240" rx="16" fill="#fff" transform="rotate(9 275 230)"/>
+  <text x="228" y="190" font-size="52" font-family="Arial" fill="#b91c1c" font-weight="700" transform="rotate(9 275 230)">A♦</text>
+  <text x="256" y="454" text-anchor="middle" font-size="58" font-family="Arial" fill="#facc15" font-weight="700">21</text>
+</svg>

--- a/blackjack/index.html
+++ b/blackjack/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Blackjack vs Bots</title>
+  <style>
+    body{font-family:Arial,sans-serif;background:#1f2937;color:#fff;margin:0;padding:20px}
+    .table{max-width:920px;margin:auto;background:#111827;padding:20px;border-radius:16px}
+    .cards{display:flex;gap:8px;flex-wrap:wrap}
+    .card{background:#fff;color:#111;padding:10px 12px;border-radius:8px;min-width:42px;text-align:center;font-weight:700}
+    button{padding:10px 14px;border:0;border-radius:8px;cursor:pointer;margin-right:8px}
+    #status{white-space:pre-line;background:#0b1220;padding:10px;border-radius:8px;margin-top:10px}
+  </style>
+</head>
+<body>
+<div class="table">
+  <h1>Blackjack vs 2 Bots</h1>
+  <p>Get closer to 21 than bots without busting.</p>
+  <div id="you"></div>
+  <button onclick="hit()">Hit</button><button onclick="stand()">Stand</button><button onclick="newGame()">New Game</button>
+  <div id="bots"></div>
+  <div id="status"></div>
+</div>
+<script>
+const suits=['♠','♥','♦','♣'];
+const ranks=['A','2','3','4','5','6','7','8','9','10','J','Q','K'];
+let d=[],you=[],bots=[[],[]],over=false;
+function deck(){const a=[];for(const s of suits)for(const r of ranks)a.push({r,s});return a.sort(()=>Math.random()-.5)}
+function score(h){let total=0,aces=0;for(const c of h){if(c.r==='A'){aces++;total+=11}else if(['J','Q','K'].includes(c.r)) total+=10; else total+=+c.r}while(total>21&&aces){total-=10;aces--}return total}
+const hand=h=>`<div class="cards">${h.map(c=>`<div class='card'>${c.r}${c.s}</div>`).join('')}</div>`;
+function draw(){document.getElementById('you').innerHTML=`<h3>You (${score(you)})</h3>${hand(you)}`;document.getElementById('bots').innerHTML=bots.map((b,i)=>`<h3>Bot ${i+1} (${over?score(b):'?'})</h3>${hand(over?b:[b[0],{r:'?',s:'?'}])}`).join('')}
+function end(){over=true;for(const b of bots){while(score(b)<17)b.push(d.pop())}draw();const ys=score(you);let msg='';if(ys>21)msg='You busted. ';const results=bots.map((b,i)=>{const s=score(b);if(s>21|| (ys<=21&&ys>s)) return `You beat Bot ${i+1}`; if(ys===s) return `Push with Bot ${i+1}`; return `Bot ${i+1} wins`;});document.getElementById('status').textContent=msg+results.join('\n')}
+function hit(){if(over)return;you.push(d.pop());draw();if(score(you)>21)end()}
+function stand(){if(!over)end()}
+function newGame(){d=deck();you=[d.pop(),d.pop()];bots=[[d.pop(),d.pop()],[d.pop(),d.pop()]];over=false;document.getElementById('status').textContent='';draw()}
+newGame();
+</script>
+</body>
+</html>

--- a/games.html
+++ b/games.html
@@ -181,9 +181,9 @@
                 <a class="gamebutton" href="rlyvtx/index.html"><img src="rlyvtx/icon.png"></a>
                 <a class="gamebutton" href="tnyfsh/index.html"><img src="tnyfsh/icon.png"></a>
                 <a class="gamebutton" href="egycr/index.html"><img src="egycr/icon.png"></a>
-                <a class="gamebutton" href="adventure/index.html"><img src="https://static.wikia.nocookie.net/adventure-capitalist/images/b/bf/AdVentureCapitalistIcon.png"></a>
-                <a class="gamebutton" href="poker/index.html"><img src="https://images.unsplash.com/photo-1511193311914-0346f16efe90?auto=format&fit=crop&w=300&q=80"></a>
-                <a class="gamebutton" href="blackjack/index.html"><img src="https://images.unsplash.com/photo-1596838132731-3301c3fd4317?auto=format&fit=crop&w=300&q=80"></a>
+                <a class="gamebutton" href="adventure/index.html"><img src="adventure/icon.svg"></a>
+                <a class="gamebutton" href="poker/index.html"><img src="poker/icon.svg"></a>
+                <a class="gamebutton" href="blackjack/index.html"><img src="blackjack/icon.svg"></a>
             </div>
         </section>
 

--- a/games.html
+++ b/games.html
@@ -159,7 +159,7 @@
         </section>
 
         <section class="homework-section">
-            <h1>Homework Tasks (20)</h1>
+            <h1>Homework Tasks (23)</h1>
             <div class="games">
                 <a class="gamebutton" href="twenT48/index.html"><img src="twenT48/icon.png"></a>
                 <a class="gamebutton" href="hxtrs/index.html"><img src="hxtrs/icon.png"></a>
@@ -181,6 +181,9 @@
                 <a class="gamebutton" href="rlyvtx/index.html"><img src="rlyvtx/icon.png"></a>
                 <a class="gamebutton" href="tnyfsh/index.html"><img src="tnyfsh/icon.png"></a>
                 <a class="gamebutton" href="egycr/index.html"><img src="egycr/icon.png"></a>
+                <a class="gamebutton" href="adventure/index.html"><img src="https://static.wikia.nocookie.net/adventure-capitalist/images/b/bf/AdVentureCapitalistIcon.png"></a>
+                <a class="gamebutton" href="poker/index.html"><img src="https://images.unsplash.com/photo-1511193311914-0346f16efe90?auto=format&fit=crop&w=300&q=80"></a>
+                <a class="gamebutton" href="blackjack/index.html"><img src="https://images.unsplash.com/photo-1596838132731-3301c3fd4317?auto=format&fit=crop&w=300&q=80"></a>
             </div>
         </section>
 

--- a/poker/icon.svg
+++ b/poker/icon.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#14532d"/>
+      <stop offset="100%" stop-color="#052e16"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="48" fill="url(#bg)"/>
+  <rect x="88" y="110" width="220" height="300" rx="18" fill="#fff" stroke="#e5e7eb" stroke-width="8"/>
+  <text x="120" y="170" font-size="56" font-family="Arial" fill="#dc2626" font-weight="700">A♥</text>
+  <g transform="translate(340,290)">
+    <circle r="90" fill="#b91c1c" stroke="#fca5a5" stroke-width="10"/>
+    <circle r="58" fill="#ef4444"/>
+    <text y="14" text-anchor="middle" font-size="52" font-family="Arial" fill="#fff" font-weight="700">$</text>
+  </g>
+</svg>

--- a/poker/index.html
+++ b/poker/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Poker vs Bots</title>
+  <style>
+    body{font-family:Arial,sans-serif;background:#0f5132;color:#fff;margin:0;padding:20px}
+    .table{max-width:900px;margin:auto;background:#0b3d27;padding:20px;border-radius:16px}
+    .cards{display:flex;gap:8px;flex-wrap:wrap;margin:8px 0}
+    .card{background:#fff;color:#111;padding:10px 12px;border-radius:8px;min-width:42px;text-align:center;font-weight:700}
+    button{padding:10px 14px;border:0;border-radius:8px;cursor:pointer;margin-right:8px}
+    #log{background:#062b1b;padding:10px;border-radius:8px;min-height:90px;white-space:pre-line}
+  </style>
+</head>
+<body>
+<div class="table">
+  <h1>Simple Poker (High Card) vs 2 Bots</h1>
+  <p>Each player gets 5 cards. Highest single card wins.</p>
+  <button onclick="deal()">Deal New Hand</button>
+  <div id="players"></div>
+  <h3>Result</h3>
+  <div id="log"></div>
+</div>
+<script>
+const suits=['♠','♥','♦','♣'];
+const ranks=['2','3','4','5','6','7','8','9','10','J','Q','K','A'];
+const val=r=>ranks.indexOf(r);
+const names=['You','Bot A','Bot B'];
+function deck(){const d=[];for(const s of suits)for(const r of ranks)d.push({r,s});return d.sort(()=>Math.random()-.5)}
+function renderHand(h){return `<div class="cards">${h.map(c=>`<div class="card">${c.r}${c.s}</div>`).join('')}</div>`}
+function best(h){return Math.max(...h.map(c=>val(c.r)))}
+function deal(){
+  const d=deck();
+  const players=names.map(n=>({n,h:d.splice(0,5)}));
+  const container=document.getElementById('players');
+  container.innerHTML=players.map(p=>`<h3>${p.n}</h3>${renderHand(p.h)}`).join('');
+  const scores=players.map(p=>({n:p.n,s:best(p.h)}));
+  const max=Math.max(...scores.map(x=>x.s));
+  const winners=scores.filter(x=>x.s===max).map(x=>x.n);
+  document.getElementById('log').textContent=`${scores.map(s=>`${s.n}: ${ranks[s.s]}`).join('\n')}\n\nWinner: ${winners.join(', ')}`;
+}
+deal();
+</script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide three new homework task tabs that host playable games directly from the site so users can access an AdVenture Capitalist embed and small web-based Poker and Blackjack games with simple bot opponents.
- Keep each game isolated in its own directory so the site structure remains organized and each game can be linked from the `games.html` task grid.

### Description
- Added `adventure/index.html` which embeds AdVenture Capitalist in a responsive iframe sized for typical gameplay and centered on the page.
- Added `poker/index.html` implementing a simple high-card Poker variant where each player (you + 2 bots) receives 5 cards and the highest card wins, with UI to deal hands and show results.
- Added `blackjack/index.html` implementing a basic Blackjack game (you vs 2 bots) with `Hit`, `Stand`, and `New Game` controls and bot drawing rules (bots hit until 17+).
- Updated `games.html` to increase the `Homework Tasks` count and add task tiles linking to the new `adventure`, `poker`, and `blackjack` pages with representative images.

### Testing
- Ran `rg -n "Homework Tasks|adventure/index|poker/index|blackjack/index" games.html` to verify the new links are present and it completed successfully.
- Printed sections with `nl -ba games.html | sed -n '150,205p'` and `nl -ba adventure/index.html | sed -n '1,120p'` (and equivalents for poker/blackjack) to confirm file contents, all commands succeeded.
- Committed the changes with `git commit` and verified the commit output to ensure the new files (`poker/index.html`, `blackjack/index.html`) and modifications (`adventure/index.html`, `games.html`) were recorded successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdea539370832c9715cd9e6a1cf87b)