### PR TITLE
Revalidate Auth0 session on page load to block revoked users

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -81,7 +81,8 @@
     },
     async requireAuth() {
       const authed = await this.isAuthenticated();
-      if (!authed) {
+      const activeSession = authed ? await verifyActiveSession() : false;
+      if (!authed || !activeSession) {
         const next = encodeURIComponent(location.pathname + location.search + location.hash);
         location.replace('/login.html?next=' + next);
       }


### PR DESCRIPTION
### Motivation
- Prevent users who were blocked/disabled in Auth0 after logging in from continuing to access protected pages like `games.html` by ensuring the page checks the live Auth0 session on load.

### Description
- Update `Auth.requireAuth()` in `auth.js` to call `verifyActiveSession()` (which uses `getTokenSilently({ cacheMode: 'off' })`) and redirect to `/login.html` when either the cached auth state or the live session validation fails.

### Testing
- Ran `git diff -- auth.js` to verify the change and `git commit` which succeeded with the message `Fix auth gating to revalidate blocked users on page load`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f19a3d864832c9ef6acd67a92efbf)