### PR TITLE
Enforce active Auth0 session and add periodic session guard

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -52,6 +52,26 @@
     history.replaceState({}, '', '/login.html' + location.hash);
   }
 
+
+  function redirectToLogin() {
+    const next = encodeURIComponent(location.pathname + location.search + location.hash);
+    location.replace('/login.html?next=' + next);
+  }
+
+  async function enforceAuth() {
+    const client = await getClient();
+    const authed = await client.isAuthenticated();
+    const activeSession = authed ? await verifyActiveSession() : false;
+    if (!authed || !activeSession) {
+      try {
+        await client.logout({ logoutParams: { returnTo: location.origin + '/login.html' }, localOnly: true });
+      } catch {}
+      redirectToLogin();
+      return false;
+    }
+    return true;
+  }
+
   window.Auth = {
     async login(isSignup) {
       const client = await getClient();
@@ -80,11 +100,20 @@
       return client.getUser();
     },
     async requireAuth() {
-      const authed = await this.isAuthenticated();
-      if (!authed) {
-        const next = encodeURIComponent(location.pathname + location.search + location.hash);
-        location.replace('/login.html?next=' + next);
-      }
+      await ensureCallbackHandled();
+      return enforceAuth();
+    },
+    startSessionGuard(intervalMs = 30000) {
+      this.requireAuth();
+      const onVisible = () => {
+        if (document.visibilityState === 'visible') this.requireAuth();
+      };
+      document.addEventListener('visibilitychange', onVisible);
+      const timer = setInterval(() => this.requireAuth(), intervalMs);
+      return () => {
+        clearInterval(timer);
+        document.removeEventListener('visibilitychange', onVisible);
+      };
     },
     async completeLoginRedirect() {
       const params = new URLSearchParams(location.search);

--- a/games.html
+++ b/games.html
@@ -103,7 +103,7 @@
     <div class="page-shell">
     <script src="https://cdn.auth0.com/js/auth0-spa-js/2.18/auth0-spa-js.production.js"></script>
     <script src="/auth.js"></script>
-    <script>(async () => { await Auth.requireAuth(); })();</script>
+    <script>(async () => { await Auth.requireAuth(); Auth.startSessionGuard(); })();</script>
     <header>
         <center> <img src="favicon.png" alt="VLE Logo" width="200" height="200"> </center>
         <h3 id="welcome">-~- Homework dashboard for planning, tracking, and opening class tasks quickly. -~-</h3>


### PR DESCRIPTION
### Motivation

- Ensure pages require not just an authenticated client but an active session with Auth0 and redirect to the login flow when sessions are missing or revoked.
- Preserve the intended post-login navigation by encoding a `next` parameter when redirecting to `/login.html`.
- Periodically re-validate the session and re-check on tab visibility to detect remote logouts or expired sessions quickly.

### Description

- Added `redirectToLogin()` to build and navigate to `/login.html?next=...` with the current path preserved.
- Added `enforceAuth()` which verifies `client.isAuthenticated()` and an active session via `verifyActiveSession()`, logs out locally on failure, and redirects to login; it returns a boolean indicating authentication success.
- Updated `requireAuth()` to call `ensureCallbackHandled()` and delegate to `enforceAuth()` for stricter session checks.
- Added `startSessionGuard(intervalMs = 30000)` to `window.Auth`, which installs a `visibilitychange` handler and a periodic timer that calls `requireAuth()` and returns a cleanup function; updated `games.html` to call `Auth.startSessionGuard()` on load.

### Testing

- Ran the project's automated test suite with `npm test` and static checks with `npm run lint`, and both completed successfully.
- No automated regressions were detected from the added session enforcement and guard logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f19a3d864832c9ef6acd67a92efbf)